### PR TITLE
Just a quick url encoding tweak to support things like symbols in passwords.

### DIFF
--- a/DropboxUploader.php
+++ b/DropboxUploader.php
@@ -190,7 +190,7 @@ class DropboxUploader {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, TRUE);
         if (NULL !== $postData) {
             curl_setopt($ch, CURLOPT_POST, TRUE);
-            curl_setopt($ch, CURLOPT_POSTFIELDS, $postData);
+            curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($postData));
         }
 
         // Send cookies


### PR DESCRIPTION
Using PHP5 method http_build_query() to ensure all post data is properly URL-encoded. This ensures, for example, passwords beginning with '@' are supported.
