### PR TITLE
Release v1.1.12

### DIFF
--- a/DropboxUploader.php
+++ b/DropboxUploader.php
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  *
  * @author Jaka Jancar [jaka@kubje.org] [http://jaka.kubje.org/]
- * @version 1.1.11
+ * @version 1.1.12
  */
 class DropboxUploader {
     /**
@@ -77,7 +77,7 @@ class DropboxUploader {
             throw new Exception('DropboxUploader requires the cURL extension.', self::CODE_CURL_EXTENSION_MISSING);
 
         if (empty($email) || empty($password)) {
-            throw new Exception(empty($email) ? 'Email' : 'Password' . ' must not be empty.', self::CODE_PARAMETER_TYPE_ERROR);
+            throw new Exception((empty($email) ? 'Email' : 'Password') . ' must not be empty.', self::CODE_PARAMETER_TYPE_ERROR);
         }
 
         $this->email    = $email;
@@ -165,7 +165,7 @@ class DropboxUploader {
             'login_password' => (string) $this->password,
             't'              => $token
         );
-        $data     = $this->request(self::HTTPS_DROPBOX_COM_LOGIN, $postData);
+        $data     = $this->request(self::HTTPS_DROPBOX_COM_LOGIN, http_build_query($postData));
 
         if (stripos($data, 'location: /home') === FALSE)
             throw new Exception('Login unsuccessful.', self::CODE_LOGIN_ERROR);
@@ -173,7 +173,7 @@ class DropboxUploader {
         $this->loggedIn = TRUE;
     }
 
-    protected function request($url, array $postData = NULL) {
+    protected function request($url, $postData = NULL) {
         $ch = curl_init();
         curl_setopt($ch, CURLOPT_URL, (string) $url);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);


### PR DESCRIPTION
This release fixes a potential security issue: In case the password started with the `@` symbol, curl would have tried to transfer a file named like it (because of the `@` in it's beginng). Transferring such a file would be a problem on it's own. But even if not, the exception message that informs about the failure contains the password in plaintext (only the `@` missing) then. If those messages are passed to the user without further checks, the password would have been leaked. Same for storing the error messages into log-files.

An exemplary error message for the exemplary password `@password` is:

> Curl error: (#26) couldn't open file "password" `CODE_CURL_ERROR`

This has been fixed now as this is a flaw. Instead the login now works or the following exception is given:

> Login unsuccessful. `CODE_LOGIN_ERROR`.

Which is the common and intended exception for any wrong password.

If you have used a password starting with the `@` symbol previously, change your dropbox password after update. Also scan the log for error messages in the pattern as given above and alter the files to remove the sensitive information.

Changes in this version:
- Fix that allows "@" ("\x40") as first character in passwords. Fixes a
  security issue. See Issue #15
- Fix error message on empty email address. Introduced in 7a12003
