### PR TITLE
Fixed CSRF token extraction.

### DIFF
--- a/DropboxUploader.php
+++ b/DropboxUploader.php
@@ -23,7 +23,7 @@
  * THE SOFTWARE.
  *
  * @author Jaka Jancar [jaka@kubje.org] [http://jaka.kubje.org/]
- * @version 1.1.14
+ * @version 1.1.15
  */
 class DropboxUploader {
     /**


### PR DESCRIPTION
This fix the issue https://github.com/jakajancar/DropboxUploader/issues/30.
Now the token value is obtained from the cookie.
